### PR TITLE
Update base image to use Zephyr v3.7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/spacebee-technologies/zephyr-environment:v0.12.0
+FROM ghcr.io/spacebee-technologies/zephyr-environment:v0.13.0
 
 USER root
 RUN /opt/venv/bin/pip install tm-tc-code-generator==0.10.1


### PR DESCRIPTION


Closes #29: Update base image to use Zephyr v3.7.2